### PR TITLE
Changed text of negative button to 'Cancel', so that AppKit wires up the escape key to the button.

### DIFF
--- a/XQuit/XQuit.m
+++ b/XQuit/XQuit.m
@@ -15,7 +15,7 @@ static NSString * const applicationTitle    = @"Xcode";
 static NSString * const menuTitle           = @"Xcode";
 static NSString * const itemTitle           = @"Quit Xcode";
 static NSString * const positiveButton      = @"Yes";
-static NSString * const negativeButton      = @"No";
+static NSString * const negativeButton      = @"Cancel";
 
 @interface XQuit()
 


### PR DESCRIPTION
You could also use -setKeyEquivalent: on the NSButton object that the -addButtonWithTitle: method call returns, but this is the path of least resistance.
